### PR TITLE
docs: changes index.rst and moves well swapping to experimental section

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,7 +19,7 @@ EVEREST™ tutorials
 
 .. toctree::
    :hidden:
-   :caption: Qualified features
+   :caption: Topics
 
    well_rate/well_rate
    well_order/well_order
@@ -30,7 +30,7 @@ EVEREST™ tutorials
 
 .. toctree::
    :hidden:
-   :caption: Experimental features
+   :caption: Experimental
 
    well_swap/well_swap
 


### PR DESCRIPTION
Closes https://github.com/equinor/everest-tutorials/issues/70

Creates **Experimental features** section in `index.rst` and moves well swapping tutorial documentation there.