### PR TITLE
test: remove disable_komodo call which is not available

### DIFF
--- a/ci/testkomodo.sh
+++ b/ci/testkomodo.sh
@@ -17,8 +17,6 @@ run_tests () {
     cp -rf . "$run_path"/everest-tutorials
     pushd "$run_path"/everest-tutorials
 
-    disable_komodo
-
     # Add /global/bin to path for access to bsub commands etc.
     # Important that this is done before sourcing komodo!!!
 


### PR DESCRIPTION
I messed up, apparently the workflow does not create the komodoenv directly in the workflow for everest-tutorial as I thought and so the script fails. I tested the branch with the changes, but I must have forgotten to rerun after pushing that last commit.

See https://github.com/equinor/komodo-releases/actions/runs/23162873576/job/67295057645