### PR TITLE
Update everest name casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Code Style](https://github.com/equinor/everest-tutorials/actions/workflows/style.yml/badge.svg)](https://github.com/equinor/everest-tutorials/actions/workflows/style.yml)
 
-Everest tutorials
+EVEREST tutorials
 
 
 

--- a/docs/source/well_order/well_order.rst
+++ b/docs/source/well_order/well_order.rst
@@ -44,7 +44,7 @@ We plan to drill 6 wells; 4 producers: A1, A2, A3, A4 and 2 injectors A5, A6. We
    "Wells","A1","A2","A3","A4","A5","A6"
    "Priorities","0.6","0.55","0.5","0.45","0.4","0.35"
 
-Let's assume, we want to start optimization with wells drilled in alphabetical order. We need to assign drilling priority value for each well. The higher the probability value the earlier the well will be drilled. This means, we need to choose the highest priority value for the first well (A1) and lowest priority for the last well (A6). See the :ref:`table_initial_controls_do` for chosen well priority values. We recommend spacing priority values evenly. We also need to specify what standard deviation to use when randomizing priorities for perturbations. We recommend setting standard deviation to be equal to difference between the priority values (0.05 for the example in :ref:`table_initial_controls_do`). For information on how to define a more complex time scheduling constraints with rig and slot availability, see relevant documentation section `(Everest documentation <https://everest.readthedocs.io/en/latest/forward_model_jobs.html#drill_planner-category>`_)
+Let's assume, we want to start optimization with wells drilled in alphabetical order. We need to assign drilling priority value for each well. The higher the probability value the earlier the well will be drilled. This means, we need to choose the highest priority value for the first well (A1) and lowest priority for the last well (A6). See the :ref:`table_initial_controls_do` for chosen well priority values. We recommend spacing priority values evenly. We also need to specify what standard deviation to use when randomizing priorities for perturbations. We recommend setting standard deviation to be equal to difference between the priority values (0.05 for the example in :ref:`table_initial_controls_do`). For information on how to define a more complex time scheduling constraints with rig and slot availability, see relevant documentation section `(EVEREST documentation <https://everest.readthedocs.io/en/latest/forward_model_jobs.html#drill_planner-category>`_)
 
 .. _objectives_wo:
 
@@ -176,7 +176,7 @@ to the correct directory path.
       :language: yaml
       :lines: 46-48
    
-   See also `Everest documentation <https://everest.readthedocs.io/en/latest/config_reference.html#>`_.
+   See also `EVEREST documentation <https://everest.readthedocs.io/en/latest/config_reference.html#>`_.
 
 To launch EVEREST, we can execute the following command in the directory with configuration file:
 
@@ -205,7 +205,7 @@ In our case we can find optimization results in ``r{{configpath}}/../output/r{{c
    Drilling order in batch 0 is the chosen initial drilling order. 
 
 .. note::
-   Depending on the choice of ``speculative`` option in ``optimization`` section, the calculations for current best solution and for the gradient might be split in multiple batches, see `Everest documentation <https://everest.readthedocs.io/en/latest/config_reference.html#>`_.
+   Depending on the choice of ``speculative`` option in ``optimization`` section, the calculations for current best solution and for the gradient might be split in multiple batches, see `EVEREST documentation <https://everest.readthedocs.io/en/latest/config_reference.html#>`_.
 
 The :ref:`figure_objectives_wo` shows average objective function at the
 iterations of the optimization experiment (average NPV over all geological realizations).

--- a/docs/source/well_selection/well_selection.rst
+++ b/docs/source/well_selection/well_selection.rst
@@ -33,7 +33,7 @@ Optimization variables
 Drilling priority values
 ************************
 
-Let's assume that we plan to select up to 5 wells out of 6 candidates and find the best drilling order; 4 producers: A1, A2, A3, A4 and 2 injectors A5, A6. We choose the starting date for drilling to be 2022-09-03. We assume that the drilling rig continuously available without any interruptions. We also assume that it takes 120 days for each well to be drilled, completed and ready to operate. This means that the dates at which wells will be opened in the model are fixed and we only select the wells to be drilled and their order. See the :ref:`table_initial_controls_ws` for resulting drilling dates based on chosen starting date and drilling times. For information on how to define a more complex time scheduling constraints with rig and slot availability, see relevant documentation section (`Everest documentation <https://everest.readthedocs.io/en/latest/forward_model_jobs.html#drill_planner-category>`_).
+Let's assume that we plan to select up to 5 wells out of 6 candidates and find the best drilling order; 4 producers: A1, A2, A3, A4 and 2 injectors A5, A6. We choose the starting date for drilling to be 2022-09-03. We assume that the drilling rig continuously available without any interruptions. We also assume that it takes 120 days for each well to be drilled, completed and ready to operate. This means that the dates at which wells will be opened in the model are fixed and we only select the wells to be drilled and their order. See the :ref:`table_initial_controls_ws` for resulting drilling dates based on chosen starting date and drilling times. For information on how to define a more complex time scheduling constraints with rig and slot availability, see relevant documentation section (`EVEREST documentation <https://everest.readthedocs.io/en/latest/forward_model_jobs.html#drill_planner-category>`_).
 
 .. _table_initial_controls_ws:
 .. csv-table:: Table: Initial priority values
@@ -44,7 +44,7 @@ Let's assume that we plan to select up to 5 wells out of 6 candidates and find t
    "Wells","A1","A2","A3","A4","A5","A6"
    "Priorities","0.6","0.55","0.5","0.45","0.4","0.35"
 
-Let's assume, we want to start optimization with the first 4 wells selected based on alphabetical order of their names. We need to assign drilling priority value for each well. The higher the priority value the more likely the well will be selected. This means, we need to choose the highest priority value for the first well (A1) and lowest priority for the last well (A6). See the :ref:`table_initial_controls_ws` for chosen well priority values. We recommend spacing priority values evenly. We also need to specify what standard deviation to use when randomizing priorities for perturbations. We recommend setting standard deviation to be equal to difference between the priority values (0.05 for the example in :ref:`table_initial_controls_ws`). In addition, we will need another control variable to specify the number of wells selected. In our case, we will start with the first 4 wells and we will also specify that we are searching for optimal number of wells between 1 and 5. It is also possible to specified fixed number of wells to be selected, see relevant documentation section (`Everest documentation <https://everest.readthedocs.io/en/latest/forward_model_jobs.html#select_wells-category>`_).
+Let's assume, we want to start optimization with the first 4 wells selected based on alphabetical order of their names. We need to assign drilling priority value for each well. The higher the priority value the more likely the well will be selected. This means, we need to choose the highest priority value for the first well (A1) and lowest priority for the last well (A6). See the :ref:`table_initial_controls_ws` for chosen well priority values. We recommend spacing priority values evenly. We also need to specify what standard deviation to use when randomizing priorities for perturbations. We recommend setting standard deviation to be equal to difference between the priority values (0.05 for the example in :ref:`table_initial_controls_ws`). In addition, we will need another control variable to specify the number of wells selected. In our case, we will start with the first 4 wells and we will also specify that we are searching for optimal number of wells between 1 and 5. It is also possible to specified fixed number of wells to be selected, see relevant documentation section (`EVEREST documentation <https://everest.readthedocs.io/en/latest/forward_model_jobs.html#select_wells-category>`_).
 
 .. note::
    This tutorial extends on the well order tutorial where priority values were used to define drilling order of the wells. Here, meaning of the priority is similar, i.e. the higher the priority value for the well is, the earlier the well will be drillied. However, in addition, the more likely that well will be selected. The number of wells variable acts as a cut-off for the number of wells selected with the highest priorities. 
@@ -183,7 +183,7 @@ to the correct directory path.
       :language: yaml
       :lines: 54-56
    
-   See also `Everest documentation <https://everest.readthedocs.io/en/latest/config_reference.html#>`_.
+   See also `EVEREST documentation <https://everest.readthedocs.io/en/latest/config_reference.html#>`_.
 
 To launch EVEREST, we can execute the following command in the directory with configuration file:
 
@@ -212,7 +212,7 @@ In our case we can find optimization results in ``r{{configpath}}/../output/r{{c
    Well selection scenario in batch 0 is the chosen initial well selection scenario. 
 
 .. note::
-   Depending on the choice of ``speculative`` option in ``optimization`` section, the calculations for current best solution and for the gradient might be split in multiple batches, see `Everest documentation <https://everest.readthedocs.io/en/latest/config_reference.html#>`_.
+   Depending on the choice of ``speculative`` option in ``optimization`` section, the calculations for current best solution and for the gradient might be split in multiple batches, see `EVEREST documentation <https://everest.readthedocs.io/en/latest/config_reference.html#>`_.
 
 The :ref:`figure_objectives_ws` shows average objective function at the
 iterations of the optimization experiment (average NPV over all geological realizations).

--- a/tests/drogon/test_control_sensitivities.py
+++ b/tests/drogon/test_control_sensitivities.py
@@ -20,7 +20,7 @@ def test_control_sensitivities_simulation(capsys):
     try:
         everest_entry([str(config_path), "--skip-prompt"])
     except SystemExit as e:
-        pytest.fail(f"Everest exited with SystemExit: {e}")
+        pytest.fail(f"EVEREST exited with SystemExit: {e}")
 
     captured = capsys.readouterr()
-    assert "Everest run finished with" in captured.out
+    assert "EVEREST run finished with" in captured.out

--- a/tests/drogon/test_well_order.py
+++ b/tests/drogon/test_well_order.py
@@ -18,7 +18,7 @@ def test_well_order_simulation(capsys):
     try:
         everest_entry([str(config_path), "--skip-prompt"])
     except SystemExit as e:
-        pytest.fail(f"Everest exited with SystemExit: {e}")
+        pytest.fail(f"EVEREST exited with SystemExit: {e}")
 
     captured = capsys.readouterr()
-    assert "Everest run finished with" in captured.out
+    assert "EVEREST run finished with" in captured.out

--- a/tests/drogon/test_well_rate.py
+++ b/tests/drogon/test_well_rate.py
@@ -19,7 +19,7 @@ def test_well_rate_simulation(capsys):
     try:
         everest_entry([str(config_path), "--skip-prompt"])
     except SystemExit as e:
-        pytest.fail(f"Everest exited with SystemExit: {e}")
+        pytest.fail(f"EVEREST exited with SystemExit: {e}")
 
     captured = capsys.readouterr()
-    assert "Everest run finished with" in captured.out
+    assert "EVEREST run finished with" in captured.out

--- a/tests/drogon/test_well_selection.py
+++ b/tests/drogon/test_well_selection.py
@@ -21,7 +21,7 @@ def test_well_selection_simulation(capsys):
     try:
         everest_entry([str(config_path), "--skip-prompt"])
     except SystemExit as e:
-        pytest.fail(f"Everest exited with SystemExit: {e}")
+        pytest.fail(f"EVEREST exited with SystemExit: {e}")
 
     captured = capsys.readouterr()
-    assert "Everest run finished with" in captured.out
+    assert "EVEREST run finished with" in captured.out

--- a/tests/drogon/test_well_swap.py
+++ b/tests/drogon/test_well_swap.py
@@ -19,7 +19,7 @@ def test_well_swap_simulation(capsys):
     try:
         everest_entry([str(config_path), "--skip-prompt"])
     except SystemExit as e:
-        pytest.fail(f"Everest exited with SystemExit: {e}")
+        pytest.fail(f"EVEREST exited with SystemExit: {e}")
 
     captured = capsys.readouterr()
-    assert "Everest run finished with" in captured.out
+    assert "EVEREST run finished with" in captured.out

--- a/tests/drogon/test_well_trajectory.py
+++ b/tests/drogon/test_well_trajectory.py
@@ -37,7 +37,7 @@ def test_well_trajectory_simulation(capsys):
     try:
         everest_entry([str(config_path), "--skip-prompt"])
     except SystemExit as e:
-        pytest.fail(f"Everest exited with SystemExit: {e}")
+        pytest.fail(f"EVEREST exited with SystemExit: {e}")
 
     captured = capsys.readouterr()
-    assert "Everest run finished with" in captured.out
+    assert "EVEREST run finished with" in captured.out

--- a/tests/egg/test_egg.py
+++ b/tests/egg/test_egg.py
@@ -9,7 +9,7 @@ def test_egg_simulation(capsys):
     try:
         everest_entry(["data/egg/everest/model/egg.yml", "--skip-prompt"])
     except SystemExit as e:
-        pytest.fail(f"Everest exited with SystemExit: {e}")
+        pytest.fail(f"EVEREST exited with SystemExit: {e}")
 
     captured = capsys.readouterr()
-    assert "Everest run finished with" in captured.out
+    assert "EVEREST run finished with" in captured.out


### PR DESCRIPTION
We need to also change the expected casing in tests given the recent change in ERT, where the casing for `everest` was altered; https://github.com/equinor/ert/commit/8f58f890eb97ba47b3b5a57bf291e712c2140565

Failed in tests:
https://github.com/equinor/komodo-releases/actions/runs/23710887350/job/69070314757